### PR TITLE
Fix Docker File

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:alpine
 COPY . /app
 WORKDIR /app
 
-RUN go build
+RUN go build -o main
 
 EXPOSE 8000
 
-CMD ["./webproxy"]
+CMD ["./main"]


### PR DESCRIPTION
# 変更点
1. Dockerファイル内でgoのバイナリファイル作成時に名前を指定している
2. CMDの引数は1で指定した名前のバイナリで起動するように変更